### PR TITLE
Update Cache.php

### DIFF
--- a/src/Drivers/file/Cache.php
+++ b/src/Drivers/file/Cache.php
@@ -75,7 +75,7 @@ class Cache implements CacheInterface
             $key->getKeyName(),
             serialize(new FileCacheRegister(
                 $value,
-                $ttlInMillis == 0 ? 0 : microtime() + $ttlInMillis * 1000
+                $ttlInMillis == 0 ? 0 : microtime(1) + $ttlInMillis * 1000
             ))
         );
     }


### PR DESCRIPTION
microtime() default parameter is false or 0, and it returns time in microseconds in String format, because of that the php is compaining about "A non well formed numeric value encountered".

The solution is to give a "1" or true as parameter so microtime(1) will return a float value.